### PR TITLE
Add millimeters support, AppCompat version of text widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ You can also define a custom `PrintSize` of your choice, using the static method
 - `PrintSize.fromMils(int, int)`: sets the content size in *mils*, that is, thousandth-s of an inch.
 - `PrintSize.fromPoints(float, float)`: sets the content size in *points*, that is, 72th-s of an inch.
 - `PrintSize.fromInches(float, float)`: sets the content size in *inches*.
+- `PrintSize.fromMillimeters(int, int)`: sets the content size in *millimeters*.
 - `PrintSize.fromPixels(Context, float, float)`: sets the content size in *pixels*. We need a valid context to know the display metrics.
 
 There is no preferable API - it's up to your content and how you want to deal with it.
@@ -204,6 +205,7 @@ android:layout_width="20pt"
 android:layout_width="2in"
 android:layout_width="2px"
 android:textSize="20px"
+app:pageInsets="30mm"
 ```
 
 Depending on what you do, standard units like `sp` and `dp` *might* make no sense here.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ A few notes:
 
 - For text, please use `DocumentTextView`: it will notify the parent when it gets bigger.
 - For editable text, please use `DocumentEditText`: same as above.
+- If using app compat, you might want to use the `AppCompat-` version of these widgets.
 - We can't split text of a single view into multiple pages or columns. 
   It is your responsibility to have Views that are small enough to avoid blank spaces.
 

--- a/demo/src/main/res/layout/content.xml
+++ b/demo/src/main/res/layout/content.xml
@@ -19,67 +19,67 @@
             android:layout_height="wrap_content"/>
     </LinearLayout>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="ViewPrinter Preview Document"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Subtitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="An overview of the printer library.\nhttps://github.com/natario1/ViewPrinter"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Header1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="A non editable paragraph"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vel quam elementum pulvinar etiam non quam lacus suspendisse. Morbi blandit cursus risus at ultrices mi tempus imperdiet. Hendrerit dolor magna eget est lorem. Vestibulum morbi blandit cursus risus at ultrices mi. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque eleifend donec. Sed cras ornare arcu dui vivamus arcu. Nec sagittis aliquam malesuada bibendum arcu vitae elementum curabitur. In aliquam sem fringilla ut morbi tincidunt augue interdum. Viverra vitae congue eu consequat ac felis donec. At lectus urna duis convallis convallis tellus id. Ultrices dui sapien eget mi. Est ultricies integer quis auctor."/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Egestas sed tempus urna et pharetra pharetra massa massa. Nisi scelerisque eu ultrices vitae auctor eu augue ut. Urna neque viverra justo nec ultrices dui sapien eget. Facilisis volutpat est velit egestas dui id. Libero enim sed faucibus turpis in eu mi bibendum. Pellentesque dignissim enim sit amet venenatis urna cursus eget. Commodo nulla facilisi nullam vehicula ipsum a arcu cursus. Augue interdum velit euismod in pellentesque massa. Ac felis donec et odio pellentesque diam volutpat. Lorem ipsum dolor sit amet. Cras semper auctor neque vitae. Iaculis eu non diam phasellus vestibulum lorem sed risus. Mi sit amet mauris commodo quis imperdiet massa."/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Egestas sed tempus urna et pharetra pharetra massa massa. Nisi scelerisque eu ultrices vitae auctor eu augue ut. Urna neque viverra justo nec ultrices dui sapien eget. Facilisis volutpat est velit egestas dui id. Libero enim sed faucibus turpis in eu mi bibendum. Pellentesque dignissim enim sit amet venenatis urna cursus eget. Commodo nulla facilisi nullam vehicula ipsum a arcu cursus. Augue interdum velit euismod in pellentesque massa. Ac felis donec et odio pellentesque diam volutpat. Lorem ipsum dolor sit amet. Cras semper auctor neque vitae. Iaculis eu non diam phasellus vestibulum lorem sed risus. Mi sit amet mauris commodo quis imperdiet massa."/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Header1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Something trickier"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph.Strong"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="It\'s easy to have something right-aligned:"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph.RightAlign"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Quis viverra nibh cras pulvinar mattis. Nec sagittis aliquam malesuada bibendum arcu vitae elementum. Sit amet nisl purus in mollis nunc. Viverra suspendisse potenti nullam ac tortor. Ut porttitor leo a diam sollicitudin. Tincidunt praesent semper feugiat nibh sed. Vulputate ut pharetra sit amet aliquam id diam maecenas. Adipiscing diam donec adipiscing tristique risus nec feugiat in fermentum. Erat velit scelerisque in dictum non. Eget est lorem ipsum dolor sit amet. Sit amet venenatis urna cursus. Sed egestas egestas fringilla phasellus faucibus scelerisque eleifend. Cursus metus aliquam eleifend mi in nulla posuere. Volutpat diam ut venenatis tellus in metus vulputate eu. Amet risus nullam eget felis eget nunc lobortis mattis aliquam. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet."/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph.Strong"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Actually, it's easy to do anything you can do with a TextView, using XML or programmatically. The PDF result will be even selectable!"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -90,25 +90,25 @@
         android:textColor="@color/colorPrimaryDark"
         android:text="Risus commodo viverra maecenas accumsan. Ut morbi tincidunt augue interdum velit euismod. Lectus urna duis convallis convallis tellus. Tellus elementum sagittis vitae et leo duis ut. Tortor pretium viverra suspendisse potenti nullam. Viverra tellus in hac habitasse. Dolor magna eget est lorem ipsum dolor sit amet consectetur. Lorem ipsum dolor sit amet consectetur. Purus non enim praesent elementum facilisis leo vel. Eget egestas purus viverra accumsan in. Bibendum ut tristique et egestas quis ipsum suspendisse. Sit amet luctus venenatis lectus magna fringilla urna porttitor. Dui vivamus arcu felis bibendum. Sed enim ut sem viverra aliquet. Bibendum est ultricies integer quis auctor elit sed vulputate. Sit amet cursus sit amet dictum sit amet. Mollis aliquam ut porttitor leo a diam sollicitudin tempor id. Ac orci phasellus egestas tellus rutrum tellus."/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph.Strong"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="We have the full graphical power of the Android framework, to create pages or artworks. This also means that text can be editable:"/>
 
-    <com.otaliastudios.printer.DocumentEditText
+    <com.otaliastudios.printer.view.DocumentEditText
         style="@style/Text.Paragraph"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Cras fermentum odio eu feugiat pretium nibh ipsum consequat. Nec nam aliquam sem et tortor consequat id porta nibh. Magna eget est lorem ipsum dolor sit amet..."/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Header1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Even better"/>
 
-    <com.otaliastudios.printer.DocumentTextView
+    <com.otaliastudios.printer.view.DocumentTextView
         style="@style/Text.Paragraph.Strong"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,6 +29,7 @@ android {
 }
 
 dependencies {
+    provided "com.android.support:appcompat-v7:$supportLibVersion"
     compile "com.android.support:support-annotations:$supportLibVersion"
     compile('com.otaliastudios:zoomlayout:1.0.3') { changing = true }
     // compile project(':zoomlayout')

--- a/library/src/main/java/com/otaliastudios/printer/BitmapPrinter.java
+++ b/library/src/main/java/com/otaliastudios/printer/BitmapPrinter.java
@@ -44,6 +44,8 @@ abstract class BitmapPrinter extends Printer {
         if (filename.toLowerCase().endsWith(mFormat)) {
             filename = filename.substring(0, filename.length() - 4);
         }
+        if (mDocument.getPageCount() == 0) return;
+
 
         final Handler ui = new Handler();
         final HandlerThread thread = new HandlerThread(getClass().getSimpleName() + "Worker");

--- a/library/src/main/java/com/otaliastudios/printer/DocumentColumn.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentColumn.java
@@ -94,7 +94,10 @@ class DocumentColumn extends LinearLayout implements Container<DocumentPage, Doc
 
     @Override
     public void onSpaceOver(DocumentColumn child) {
-        // We have no children so no one can call this.
+        // This can be called by child TextViews or EditText that grown
+        // to be too small. See DocumentTextHelper.
+        mLog.w("notifyTooSmall:", "one of our children says is smaller than he would like to.");
+        getRoot().onSpaceOver(this);
     }
 
     //endregion
@@ -187,15 +190,6 @@ class DocumentColumn extends LinearLayout implements Container<DocumentPage, Doc
     //endregion
 
     //region Remove childs that have grown, pass back childs that did shrink
-
-    /**
-     * A child notifies that it is being less tall than he would like to be.
-     */
-    void notifyTooSmall(View tooSmallChild, View directChild) {
-        mLog.w("notifyTooSmall:", "our child", Utils.mark(directChild),
-                "is smaller than he would like to.");
-        getRoot().onSpaceOver(this);
-    }
 
     /**
      * Something changed here.

--- a/library/src/main/java/com/otaliastudios/printer/DocumentEditText.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentEditText.java
@@ -21,9 +21,6 @@ import android.widget.EditText;
 @SuppressLint("AppCompatCustomView")
 public class DocumentEditText extends EditText {
 
-    private final static String TAG = DocumentEditText.class.getSimpleName();
-    private final static PrinterLogger LOG = PrinterLogger.create(TAG);
-
     public DocumentEditText(Context context) {
         super(context);
     }
@@ -44,33 +41,6 @@ public class DocumentEditText extends EditText {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        if (getLayoutParams().height == ViewGroup.LayoutParams.WRAP_CONTENT) {
-            LOG.i("onLayout:", "We are wrap content. Looking if we can scroll.");
-            if (canScrollVertically(-1) || canScrollVertically(1)) {
-                LOG.w("onLayout:", "We can scroll. Notifying the parent column.");
-                notifyColumn();
-            }
-        }
-    }
-
-    private void notifyColumn() {
-        DocumentColumn column = null;
-        View current = this;
-        while (true) {
-            ViewParent parent = current.getParent();
-            if (parent == null || !(parent instanceof ViewGroup)) {
-                break;
-            }
-
-            if (parent instanceof DocumentColumn) {
-                column = (DocumentColumn) parent;
-                break;
-            }
-            current = (ViewGroup) parent;
-        }
-
-        if (column != null) {
-            column.notifyTooSmall(this, current);
-        }
+        DocumentTextHelper.onLayout(this);
     }
 }

--- a/library/src/main/java/com/otaliastudios/printer/DocumentTextHelper.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentTextHelper.java
@@ -1,0 +1,63 @@
+package com.otaliastudios.printer;
+
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.EditText;
+import android.widget.TextView;
+
+/**
+ * Static utilities for text containers that might become smaller than they would like to,
+ * without notifying the parent.
+ *
+ * It is recommended that they call {@link #onLayout(View)} here to have our splitting
+ * policy working.
+ *
+ * @see DocumentTextView
+ * @see DocumentEditText
+ */
+public class DocumentTextHelper {
+
+    private final static String TAG = DocumentTextHelper.class.getSimpleName();
+    private final static PrinterLogger LOG = PrinterLogger.create(TAG);
+
+    public static void onLayout(View view) {
+        if (view.getLayoutParams().height == ViewGroup.LayoutParams.WRAP_CONTENT) {
+            LOG.i("onLayout:", "We are wrap content. Looking if we can scroll.");
+            // TODO: don't do this if getMaxLines is >= 0 (< MAX_VALUE). Same for getMaxheight.
+            if (view.canScrollVertically(-1) || view.canScrollVertically(1)) {
+                LOG.w("onLayout:", "We can scroll. Notifying the parent column.");
+                notifyContainer(view);
+            }
+        }
+    }
+
+    private static void notifyContainer(View view) {
+        Container<?, ?> container = null;
+        View current = view;
+        while (true) {
+            ViewParent parent = current.getParent();
+            if (parent == null || !(parent instanceof ViewGroup)) {
+                break;
+            }
+
+            if (parent instanceof Container) {
+                container = (Container) parent;
+                break;
+            }
+            current = (ViewGroup) parent;
+        }
+
+        if (container != null) {
+            // View smallChild = this
+            // View directChild = current
+            container.onSpaceOver(null);
+        }
+    }
+}

--- a/library/src/main/java/com/otaliastudios/printer/DocumentTextHelper.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentTextHelper.java
@@ -1,16 +1,12 @@
 package com.otaliastudios.printer;
 
 
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
-import android.content.Context;
-import android.support.annotation.Nullable;
-import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
-import android.widget.EditText;
-import android.widget.TextView;
+
+import com.otaliastudios.printer.view.DocumentEditText;
+import com.otaliastudios.printer.view.DocumentTextView;
 
 /**
  * Static utilities for text containers that might become smaller than they would like to,

--- a/library/src/main/java/com/otaliastudios/printer/DocumentTextView.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentTextView.java
@@ -22,9 +22,6 @@ import android.widget.TextView;
 @SuppressLint("AppCompatCustomView")
 public class DocumentTextView extends TextView {
 
-    private final static String TAG = DocumentTextView.class.getSimpleName();
-    private final static PrinterLogger LOG = PrinterLogger.create(TAG);
-
     public DocumentTextView(Context context) {
         super(context);
     }
@@ -45,34 +42,6 @@ public class DocumentTextView extends TextView {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        if (getLayoutParams().height == ViewGroup.LayoutParams.WRAP_CONTENT) {
-            LOG.i("onLayout:", "We are wrap content. Looking if we can scroll.");
-            // TODO: don't do this if getMaxLines is >= 0 (< MAX_VALUE). Same for getMaxheight.
-            if (canScrollVertically(-1) || canScrollVertically(1)) {
-                LOG.w("onLayout:", "We can scroll. Notifying the parent column.");
-                notifyColumn();
-            }
-        }
-    }
-
-    private void notifyColumn() {
-        DocumentColumn column = null;
-        View current = this;
-        while (true) {
-            ViewParent parent = current.getParent();
-            if (parent == null || !(parent instanceof ViewGroup)) {
-                break;
-            }
-
-            if (parent instanceof DocumentColumn) {
-                column = (DocumentColumn) parent;
-                break;
-            }
-            current = (ViewGroup) parent;
-        }
-
-        if (column != null) {
-            column.notifyTooSmall(this, current);
-        }
+        DocumentTextHelper.onLayout(this);
     }
 }

--- a/library/src/main/java/com/otaliastudios/printer/DocumentView.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentView.java
@@ -39,12 +39,13 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
  * collecting all the views, removing them, and adding them to a new shaped layout.
  * The same is true for other APIs as well.
  */
-public final class DocumentView extends ZoomLayout implements View.OnLayoutChangeListener {
+public class DocumentView extends ZoomLayout implements View.OnLayoutChangeListener {
 
     // Internal note: the whole hierarchy currently relies on the fact that all columns are equal
     // Think for example of the Untakable flag which is persisted among columns.
 
     // TODO: view shadows are not drawn, https://stackoverflow.com/questions/34711211/draw-elevation-shadows-to-canvas
+    // TODO: scrollToPage() API
 
     private final static String TAG = DocumentView.class.getSimpleName();
     private final static PrinterLogger LOG = PrinterLogger.create(TAG);

--- a/library/src/main/java/com/otaliastudios/printer/PdfPrinter.java
+++ b/library/src/main/java/com/otaliastudios/printer/PdfPrinter.java
@@ -59,6 +59,7 @@ public final class PdfPrinter extends Printer {
         final File file = new File(directory, filename);
         if (!checkFile(printId, file)) return;
 
+        if (mDocument.getPageCount() == 0) return;
         DocumentPage firstPage = mDocument.getPageAt(0);
         PrintSize size = mDocument.getPdfSize();
 

--- a/library/src/main/java/com/otaliastudios/printer/PrintSize.java
+++ b/library/src/main/java/com/otaliastudios/printer/PrintSize.java
@@ -121,6 +121,18 @@ public final class PrintSize {
 
     /**
      * Creates a {@link PrintSize} out of its exact dimensions
+     * in millimeters.
+     *
+     * @param widthMm width in millimeters
+     * @param heightMm height in millimeters
+     * @return a new size
+     */
+    public static PrintSize fromMillimeters(int widthMm, int heightMm) {
+        return fromInches(widthMm * MM_TO_INCHES, heightMm * MM_TO_INCHES);
+    }
+
+    /**
+     * Creates a {@link PrintSize} out of its exact dimensions
      * in pixels.
      *
      * @param context a valid context
@@ -212,6 +224,24 @@ public final class PrintSize {
     }
 
     /**
+     * Returns the width of this size in millimeters.
+     *
+     * @return width in millimeters
+     */
+    public int widthMillimeters() {
+        return (int) (widthInches() * INCHES_TO_MM);
+    }
+
+    /**
+     * Returns the height of this size in millimeters.
+     *
+     * @return height in millimeters
+     */
+    public int heightMillimeters() {
+        return (int) (heightInches() * INCHES_TO_MM);
+    }
+
+    /**
      * Returns the width of this size in pixels,
      * based on the current display. Throws if this size
      * is equal to {@link #WRAP_CONTENT}.
@@ -277,10 +307,25 @@ public final class PrintSize {
     static float MILS_TO_INCHES = 1f / 1000f;
     static float INCHES_TO_POINTS = 72f;
     static float POINTS_TO_INCHES = 1f / 72f;
+    static float INCHES_TO_MM = 25.4f;
+    static float MM_TO_INCHES = 1f / 25.4f;
+
     static float INCHES_TO_PIXELS(Context context) {
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();
         return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_IN, 1, metrics);
     }
-    static float PIXELS_TO_INCHES(Context context) { return 1f / INCHES_TO_PIXELS(context); }
+
+    static float MM_TO_PIXELS(Context context) {
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_MM, 1, metrics);
+    }
+
+    static float PIXELS_TO_INCHES(Context context) {
+        return 1f / INCHES_TO_PIXELS(context);
+    }
+
+    static float PIXELS_TO_MM(Context context) {
+        return 1f / MM_TO_PIXELS(context);
+    }
 
 }

--- a/library/src/main/java/com/otaliastudios/printer/view/AppCompatDocumentEditText.java
+++ b/library/src/main/java/com/otaliastudios/printer/view/AppCompatDocumentEditText.java
@@ -1,0 +1,39 @@
+package com.otaliastudios.printer.view;
+
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.AppCompatEditText;
+import android.util.AttributeSet;
+
+import com.otaliastudios.printer.DocumentTextHelper;
+import com.otaliastudios.printer.DocumentView;
+
+/**
+ * A {@link AppCompatDocumentEditText} implementation that works well when
+ * laid out inside a {@link DocumentView}.
+ * Don't use if you don't have appcompat in your classpath.
+ *
+ * @see AppCompatDocumentTextView
+ * @see DocumentTextHelper
+ */
+public class AppCompatDocumentEditText extends AppCompatEditText {
+
+    public AppCompatDocumentEditText(Context context) {
+        super(context);
+    }
+
+    public AppCompatDocumentEditText(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public AppCompatDocumentEditText(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        DocumentTextHelper.onLayout(this);
+    }
+}

--- a/library/src/main/java/com/otaliastudios/printer/view/AppCompatDocumentTextView.java
+++ b/library/src/main/java/com/otaliastudios/printer/view/AppCompatDocumentTextView.java
@@ -1,0 +1,40 @@
+package com.otaliastudios.printer.view;
+
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.AppCompatTextView;
+import android.util.AttributeSet;
+
+import com.otaliastudios.printer.DocumentTextHelper;
+import com.otaliastudios.printer.DocumentView;
+import com.otaliastudios.printer.view.AppCompatDocumentEditText;
+
+/**
+ * A {@link android.support.v7.widget.AppCompatTextView} implementation that works well when
+ * laid out inside a {@link DocumentView}.
+ * Don't use if you don't have appcompat in your classpath.
+ *
+ * @see AppCompatDocumentEditText
+ * @see DocumentTextHelper
+ */
+public class AppCompatDocumentTextView extends AppCompatTextView {
+
+    public AppCompatDocumentTextView(Context context) {
+        super(context);
+    }
+
+    public AppCompatDocumentTextView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public AppCompatDocumentTextView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        DocumentTextHelper.onLayout(this);
+    }
+}

--- a/library/src/main/java/com/otaliastudios/printer/view/DocumentEditText.java
+++ b/library/src/main/java/com/otaliastudios/printer/view/DocumentEditText.java
@@ -1,4 +1,4 @@
-package com.otaliastudios.printer;
+package com.otaliastudios.printer.view;
 
 
 import android.annotation.SuppressLint;
@@ -6,17 +6,18 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
 import android.widget.EditText;
+
+import com.otaliastudios.printer.DocumentTextHelper;
+import com.otaliastudios.printer.DocumentView;
+import com.otaliastudios.printer.view.DocumentTextView;
 
 /**
  * An {@link EditText} implementation that works well when laid out inside
  * a {@link DocumentView}.
  *
  * @see DocumentTextView
+ * @see DocumentTextHelper
  */
 @SuppressLint("AppCompatCustomView")
 public class DocumentEditText extends EditText {

--- a/library/src/main/java/com/otaliastudios/printer/view/DocumentTextView.java
+++ b/library/src/main/java/com/otaliastudios/printer/view/DocumentTextView.java
@@ -1,4 +1,4 @@
-package com.otaliastudios.printer;
+package com.otaliastudios.printer.view;
 
 
 import android.annotation.SuppressLint;
@@ -6,18 +6,17 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
-import android.widget.EditText;
 import android.widget.TextView;
 
+import com.otaliastudios.printer.DocumentTextHelper;
+import com.otaliastudios.printer.DocumentView;
+
 /**
- * An {@link EditText} implementation that works well when laid out inside
+ * A {@link TextView} implementation that works well when laid out inside
  * a {@link DocumentView}.
  *
- * @see DocumentTextView
+ * @see DocumentEditText
+ * @see DocumentTextHelper
  */
 @SuppressLint("AppCompatCustomView")
 public class DocumentTextView extends TextView {


### PR DESCRIPTION
- Remove the `final` modifier from the document view
- Support for millimeters in the `PrintSize` class
- If you have app compat in your classpath, you can use `AppCompatDocumentTextView` or `AppCompatDocumentEditText`