### PR TITLE
Add print scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ public void onRequestPermissionsResult(int requestCode, @NonNull String[] permis
 
 ```java
 mPrinter = new PdfPrinter(mDocumentView, mPrintCallback);
+mPrinter.setPrintPageBackground(true);
 mPrinter.print("id", mFile, "document.pdf");
 ```
 
@@ -259,27 +260,38 @@ which defaults to `true`.
 
 ```java
 mPrinter = new PngPrinter(mDocumentView, mPrintCallback);
-mPrinter.setPrintablePages(PngPrinter.PRINTABLE_ALL);
+mPrinter.setPrintPageBackground(true);
+mPrinter.setPrintPages(PRINT_ALL);
+mPrinter.setPrintScale(1f);
 mPrinter.print("id", mFile, "my-image");
 ```
 
-The only difference here is that, if the document has multiple pages (e.g. 3), we will save three
-different files: `my-image-1.png`, `my-image-2.png`, `my-image-3.png`.
+Image printers have a couple differences with the `PdfPrinter`:
 
-This also means that the `PrintCallback` will be called three times, each time passing the 
-actual image file instance. You can choose which pages are saved using `setPrintablePages`.
+- You can choose which pages to print (defaults to all) using `setPrintPages(int...)`.
+  If more than one are selected, we will save separate files in your directory, e.g.
+  `my-image-1.png`, `my-image-2.png`, `my-image-3.png`.
+
+- This also means that the `PrintCallback` can be called multiple times, each time passing
+  the actual image file.
+  
+- You can downscale the resulting image using `setPrintScale(float)`, defaults to 1. For instance,
+  this is useful for caching low-quality previews. A `1000x1000` image with a `0.5` scale will
+  result in a `500x500` file.
 
 ### JpegPrinter
 
 ```java
 mPrinter = new JpegPrinter(mDocumentView, mPrintCallback);
-mPrinter.setPrintablePages(JpegPrinter.PRINTABLE_ALL);
-mPrinter.setQuality(90);
+mPrinter.setPrintPageBackground(true);
+mPrinter.setPrintablePages(PRINT_ALL);
+mPrinter.setPrintScale(1f);
+mPrinter.setPrintQuality(90);
 mPrinter.print("id", mFile, "my-image");
 ```
 
-On top of the `PngPrinter` functionality, this will let you specify a compression quality
-using `mPrinter.setQuality()`.
+On top of the `PngPrinter` functionality, this will let you specify a JPEG compression quality
+using `mPrinter.setPrintQuality()`.
 
 # Contributions
 

--- a/library/src/main/java/com/otaliastudios/printer/BitmapPrinter.java
+++ b/library/src/main/java/com/otaliastudios/printer/BitmapPrinter.java
@@ -131,8 +131,8 @@ abstract class BitmapPrinter extends Printer {
             float scale = mScale;
             scale = Math.min(scale, (float) mScaleMaxWidth / realWidth);
             scale = Math.min(scale, (float) mScaleMaxHeight / realHeight);
-            final int outWidth = (int) ((float) size.widthPixels(context) * scale);
-            final int outHeight = (int) ((float) size.heightPixels(context) * scale);
+            final int outWidth = (int) (realWidth * scale);
+            final int outHeight = (int) (realHeight * scale);
             if (Build.VERSION.SDK_INT >= 26) {
                 bitmap = Bitmap.createBitmap(outWidth, outHeight, Bitmap.Config.ARGB_8888, true);
             } else {

--- a/library/src/main/java/com/otaliastudios/printer/DocumentPage.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentPage.java
@@ -48,12 +48,12 @@ class DocumentPage extends LinearLayout implements Container<DocumentPager, Docu
         setWeightSum(mColumnCount);
         mColumns = new ArrayList<>(mColumnCount);
         for (int i = 0; i < mColumnCount; i++) {
-            // Columns can be WRAP_CONTENT. If we are not, they will receive our AT_MOST
-            // bound when measuring themselves, so it's not important.
+            // Columns can be WRAP_CONTENT in height if the page size is WRAP_CONTENT.
+            // If the page is not, we must provide and update the exact dimension,
+            // to have MATCH_PARENT work in final children.
             // We also want width=0 and gravity=1.
             DocumentColumn column = new DocumentColumn(context, i + 1, columnSize[0], columnSize[1]);
-            // addView(column, new LayoutParams(0, columnSize[1], 1));
-            addView(column, new LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1));
+            addView(column, new LayoutParams(0, columnSize[1], 1));
             mColumns.add(column);
         }
     }
@@ -86,7 +86,9 @@ class DocumentPage extends LinearLayout implements Container<DocumentPager, Docu
         // This changes the column dimensions. Recompute.
         int[] size = computeColumnSize();
         for (DocumentColumn col : mColumns) {
+            col.getLayoutParams().height = size[1];
             col.setBounds(size[0], size[1]);
+            col.requestLayout();
         }
     }
 

--- a/library/src/main/java/com/otaliastudios/printer/DocumentView.java
+++ b/library/src/main/java/com/otaliastudios/printer/DocumentView.java
@@ -300,7 +300,7 @@ public class DocumentView extends ZoomLayout implements View.OnLayoutChangeListe
         }
     }
 
-    PrintSize getPdfSize() {
+    PrintSize getPrintSize() {
         return mSize;
     }
 

--- a/library/src/main/java/com/otaliastudios/printer/JpegPrinter.java
+++ b/library/src/main/java/com/otaliastudios/printer/JpegPrinter.java
@@ -30,7 +30,7 @@ public final class JpegPrinter extends BitmapPrinter {
     }
 
     @Override
-    protected int getQuality() {
+    protected int getPrintQuality() {
         return mQuality;
     }
 
@@ -41,8 +41,34 @@ public final class JpegPrinter extends BitmapPrinter {
      * @see Bitmap#compress(Bitmap.CompressFormat, int, OutputStream)
      * @param quality a 1 to 100 value
      */
-    public void setQuality(int quality) {
+    public void setPrintQuality(int quality) {
         mQuality = quality;
+    }
+
+    /**
+     * Sets the numbers of the pages which should be printed.
+     * To print all pages (which is the default), you can pass {@link #PRINT_ALL}
+     * as the only parameter.
+     *
+     * @param pageNumbers any number of pages to be printed
+     */
+    @Override
+    public void setPrintPages(int... pageNumbers) {
+        super.setPrintPages(pageNumbers);
+    }
+
+    /**
+     * This will apply a scale (0...1) to the document print size, so that the result image
+     * is scaled to a smaller version. Defaults to 1, meaning that the output size is the
+     * document {@link PrintSize}.
+     * <p>
+     * This is useful, for example, for keeping cached previews of the documents.
+     *
+     * @param scale a scale greater than 0 and less than or equal to 1
+     */
+    @Override
+    public void setPrintScale(float scale) {
+        super.setPrintScale(scale);
     }
 
     /**

--- a/library/src/main/java/com/otaliastudios/printer/PdfPrinter.java
+++ b/library/src/main/java/com/otaliastudios/printer/PdfPrinter.java
@@ -1,20 +1,14 @@
 package com.otaliastudios.printer;
 
 
-import android.Manifest;
-import android.app.Activity;
 import android.content.Context;
-import android.content.ContextWrapper;
-import android.content.pm.PackageManager;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.graphics.pdf.PdfDocument;
-import android.os.Build;
 import android.os.Handler;
 import android.print.PrintAttributes;
 import android.print.pdf.PrintedPdfDocument;
 import android.support.annotation.NonNull;
-import android.view.ViewTreeObserver;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -61,7 +55,7 @@ public final class PdfPrinter extends Printer {
 
         if (mDocument.getPageCount() == 0) return;
         DocumentPage firstPage = mDocument.getPageAt(0);
-        PrintSize size = mDocument.getPdfSize();
+        PrintSize size = mDocument.getPrintSize();
 
         // Create doc
         PrintAttributes attrs = new PrintAttributes.Builder()

--- a/library/src/main/java/com/otaliastudios/printer/PngPrinter.java
+++ b/library/src/main/java/com/otaliastudios/printer/PngPrinter.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
 
 import java.io.File;
-import java.io.OutputStream;
 
 /**
  * A printer instance that can flawlessly print documents preview from {@link DocumentView}
@@ -28,8 +27,34 @@ public final class PngPrinter extends BitmapPrinter {
     }
 
     @Override
-    protected int getQuality() {
+    protected int getPrintQuality() {
         return 100;
+    }
+
+    /**
+     * Sets the numbers of the pages which should be printed.
+     * To print all pages (which is the default), you can pass {@link #PRINT_ALL}
+     * as the only parameter.
+     *
+     * @param pageNumbers any number of pages to be printed
+     */
+    @Override
+    public void setPrintPages(int... pageNumbers) {
+        super.setPrintPages(pageNumbers);
+    }
+
+    /**
+     * This will apply a scale (0...1) to the document print size, so that the result image
+     * is scaled to a smaller version. Defaults to 1, meaning that the output size is the
+     * document {@link PrintSize}.
+     * <p>
+     * This is useful, for example, for keeping cached previews of the documents.
+     *
+     * @param scale a scale greater than 0 and less than or equal to 1
+     */
+    @Override
+    public void setPrintScale(float scale) {
+        super.setPrintScale(scale);
     }
 
     /**


### PR DESCRIPTION
Introduces the ability to scale down png and jpeg images, either trough a 0..1 float scale, or by setting maxWidth and maxHeight of the result.